### PR TITLE
Guards against video content in episode list

### DIFF
--- a/src/containers/EpisodeList.js
+++ b/src/containers/EpisodeList.js
@@ -18,9 +18,11 @@ class EpisodeList extends Component {
 
     if(this.props.episodes) {
       const renderedList = this.props.episodes.map(
-        (episode, idx) => (
-          <EpisodeRow key={idx} podcast={this.props.podcast} episode={episode} />
-        )
+        (episode, idx) => {
+          if(episode.content_audio) {
+            return (<EpisodeRow key={idx} podcast={this.props.podcast} episode={episode} />)
+          }
+        }
       )
 
       return (


### PR DESCRIPTION
So I can listen to Radiolab, which has one episode that has video content but not audio content.